### PR TITLE
ルームの更新を抑えつつ、既読・未読判定処理を追加

### DIFF
--- a/App/ReportChat/Managers/Router.swift
+++ b/App/ReportChat/Managers/Router.swift
@@ -47,7 +47,7 @@ final class Router: ObservableObject {
                         }
                         
                         if let snapshot = snapshot, snapshot.exists {
-                            print("ログインユーザーの情報が存在します(AuthListener)")
+                            print("ログインユーザーの情報が存在します(AuthListener): \(user.uid)")
                             //ログインに成功したらUser情報を監視
                             AppManager.shared.listenToUserUpdates()
                             self.switchRootView(to: .tab)

--- a/App/ReportChat/Models/RoomResponse.swift
+++ b/App/ReportChat/Models/RoomResponse.swift
@@ -16,6 +16,7 @@ struct RoomResponse: Decodable, Hashable {
     let roomIcon: String?
     let roomName: String?
     let lastUpdated: Date
+    var readUsers: [String: Date] // ユーザーIDと最終閲覧日時
     
     //Firebaseのフィールド名と一致させる
     enum CodingKeys: String, CodingKey {
@@ -24,13 +25,15 @@ struct RoomResponse: Decodable, Hashable {
         case roomIcon = "roomicon"
         case roomName = "roomname"
         case lastUpdated
+        case readUsers
     }
     
     // Firebaseに書き込むための辞書変換
     func toDictionary() -> [String: Any] {
         var dict: [String: Any] = [
             "members": members,
-            "lastUpdated": lastUpdated
+            "lastUpdated": lastUpdated,
+            "readUsers": readUsers
         ]
         
         if let roomIcon = self.roomIcon {

--- a/App/ReportChat/Screens/Rooms/Room/RoomView.swift
+++ b/App/ReportChat/Screens/Rooms/Room/RoomView.swift
@@ -90,7 +90,8 @@ struct RoomView: View {
                                 members: [],
                                 roomIcon: "",
                                 roomName: "",
-                                lastUpdated: Date())
+                                lastUpdated: Date(),
+                                readUsers: [:])
                          )
         )
 }

--- a/App/ReportChat/ViewParts/RoomCell.swift
+++ b/App/ReportChat/ViewParts/RoomCell.swift
@@ -50,6 +50,11 @@ struct RoomCell: View {
             
             Spacer()
             
+            FontIcon.text(.materialIcon(code: .report),
+                          fontsize: iconSize)
+            .foregroundStyle(.red)
+            .hidden(!viewModel.isUnread)
+            
             Text(viewModel.room.lastUpdated.toLastUpdatedString())
                 .foregroundStyle(.secondary)
                 .font(.caption)
@@ -68,6 +73,7 @@ struct RoomCell: View {
             members: ["Friend 1", "Friend 2"],
             roomIcon: "https://1.bp.blogspot.com/-_CVATibRMZQ/XQjt4fzUmjI/AAAAAAABTNY/nprVPKTfsHcihF4py1KrLfIqioNc_c41gCLcBGAs/s400/animal_chara_smartphone_penguin.png",
             roomName: "room サンプル",
-            lastUpdated: Date()
+            lastUpdated: Date(),
+            readUsers: [:]
         )))
 }


### PR DESCRIPTION
## ルームの更新を抑えつつ、既読・未読判定処理を追加
- batchを用いてFirebaseへの送信回数を軽減
- RoomにreadUsersフィールドを追加し、ルームのLastUpdatedとの日付を比較することで未読判定